### PR TITLE
solved the error that was related to "import net"

### DIFF
--- a/scanner.ts
+++ b/scanner.ts
@@ -1,4 +1,4 @@
-import net from 'net';
+import * as net from 'net';
 import async from 'async';
 
 const { VMIP = '127.0.0.1', PORTS = '1-65535' } = process.env; //change the i.p


### PR DESCRIPTION
/usr/share/nodejs/ts-node/src/index.ts:513
    return new TSError(diagnosticText, diagnosticCodes)
           ^
TSError: ⨯ Unable to compile TypeScript:
tp.ts:1:8 - error TS1192: Module '"net"' has no default export.

1 import net from 'net';
         ~~~

    at createTSError (/usr/share/nodejs/ts-node/src/index.ts:513:12)
    at reportTSError (/usr/share/nodejs/ts-node/src/index.ts:517:19)
    at getOutput (/usr/share/nodejs/ts-node/src/index.ts:752:36)
    at Object.compile (/usr/share/nodejs/ts-node/src/index.ts:968:32)
    at Module.m._compile (/usr/share/nodejs/ts-node/src/index.ts:1056:42)
    at Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Object.require.extensions.<computed> [as .ts] (/usr/share/nodejs/ts-node/src/index.ts:1059:12)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)